### PR TITLE
Add `!lock/unlock community` for the interim until it's fixed properly

### DIFF
--- a/addons/lockdown.py
+++ b/addons/lockdown.py
@@ -13,20 +13,27 @@ class Lockdown:
 
     @commands.has_permissions(manage_messages=True)
     @commands.command(pass_context=True, name="lock")
-    async def lock(self, ctx):
-       """Lock message sending in the channel. Staff only."""
-       try:
-            overwrites_everyone = ctx.message.channel.overwrites_for(self.bot.everyone_role)
-            if overwrites_everyone.send_messages is False:
-                await self.bot.say("🔒 Channel is already locked down. Use `.unlock` to unlock.")
+    async def lock(self, ctx, arg=""):
+        """Lock message sending in the channel. Staff only."""
+        try:
+            if(arg == 'community'):
+                role = self.bot.community_role
+            else:
+                role = self.bot.everyone_role
+
+            overwrites = ctx.message.channel.overwrites_for(role)
+
+            if(overwrites.send_messages is False):
+                await self.bot.say("🔒 Channel is already locked down. Use `.unlock [community]` to unlock.")
                 return
-            overwrites_everyone.send_messages = False
-            overwrites_everyone.add_reactions = False
-            await self.bot.edit_channel_permissions(ctx.message.channel, self.bot.everyone_role, overwrites_everyone)
+            overwrites.send_messages = False
+            overwrites.add_reactions = False
+            await self.bot.edit_channel_permissions(ctx.message.channel, role, overwrites)
             await self.bot.say("🔒 Channel locked down. Only staff members may speak. Do not bring the topic to other channels or risk disciplinary actions.")
             msg = "🔒 **Lockdown**: {0} by {1} | {2}#{3}".format(ctx.message.channel.mention, ctx.message.author.mention, ctx.message.author.name, ctx.message.author.discriminator)
             await self.bot.send_message(self.bot.modlogs_channel, msg)
-       except discord.errors.Forbidden:
+
+        except discord.errors.Forbidden:
             await self.bot.say("💢 I don't have permission to do this.")
 
 
@@ -34,8 +41,8 @@ class Lockdown:
     @commands.has_permissions(manage_messages=True)
     @commands.command(pass_context=True, name="softlock")
     async def softlock(self, ctx):
-       """Lock message sending in the channel, without the "disciplinary action" note. Staff only."""
-       try:
+        """Lock message sending in the channel, without the "disciplinary action" note. Staff only."""
+        try:
             overwrites_everyone = ctx.message.channel.overwrites_for(self.bot.everyone_role)
             if overwrites_everyone.send_messages is False:
                 await self.bot.say("🔒 Channel is already locked down. Use `.unlock` to unlock.")
@@ -46,28 +53,32 @@ class Lockdown:
             await self.bot.say("🔒 Channel locked.")
             msg = "🔒 **Soft-lock**: {0} by {1} | {2}#{3}".format(ctx.message.channel.mention, ctx.message.author.mention, ctx.message.author.name, ctx.message.author.discriminator)
             await self.bot.send_message(self.bot.modlogs_channel, msg)
-       except discord.errors.Forbidden:
+        except discord.errors.Forbidden:
             await self.bot.say("💢 I don't have permission to do this.")
 
     @commands.has_permissions(manage_messages=True)
     @commands.command(pass_context=True, name="unlock")
-    async def unlock(self, ctx):
-       """Unlock message sending in the channel. Staff only."""
-       try:
-            overwrites_everyone = ctx.message.channel.overwrites_for(self.bot.everyone_role)
-            overwrites_staff = ctx.message.channel.overwrites_for(self.bot.staff_role)
-            if overwrites_everyone.send_messages == None:
+    async def unlock(self, ctx, arg=""):
+        """Unlock message sending in the channel. Staff only."""
+        try:
+            if(arg == 'community'):
+                role = self.bot.community_role
+            else:
+                role = self.bot.everyone_role
+
+            overwrites = ctx.message.channel.overwrites_for(role)
+
+            if(overwrites.send_messages is True):
                 await self.bot.say("🔓 Channel is already unlocked.")
                 return
-            overwrites_everyone.send_messages = None
-            overwrites_everyone.add_reactions = None
-            overwrites_staff.send_messages = True
-            await self.bot.edit_channel_permissions(ctx.message.channel, self.bot.everyone_role, overwrites_everyone)
-            await self.bot.edit_channel_permissions(ctx.message.channel, self.bot.staff_role, overwrites_staff)
+            overwrites.send_messages = True
+            overwrites.add_reactions = True
+            await self.bot.edit_channel_permissions(ctx.message.channel, role, overwrites)
             await self.bot.say("🔓 Channel unlocked.")
             msg = "🔓 **Unlock**: {0} by {1} | {2}#{3}".format(ctx.message.channel.mention, ctx.message.author.mention, ctx.message.author.name, ctx.message.author.discriminator)
             await self.bot.send_message(self.bot.modlogs_channel, msg)
-       except discord.errors.Forbidden:
+
+        except discord.errors.Forbidden:
             await self.bot.say("💢 I don't have permission to do this.")
 
 def setup(bot):


### PR DESCRIPTION
Adds a subcommand to `!lock` and `!unlock`. 
Passing `community` to either command will respectively deny or allow community members to speak in the current channel. Passing no argument has the same functionality as before. 