### PR TITLE
Update message location notice for #server-logs

### DIFF
--- a/addons/mod.py
+++ b/addons/mod.py
@@ -189,7 +189,7 @@ class Mod:
             rule_choice = randint(1, len(rules))
             rules[rule_choice - 1] += '\n' + hidden_term_line
             msg = "🗑 **Reset**: {} cleared {} messages in {}".format(ctx.message.author.mention, limit, ctx.message.channel.mention)
-            msg += "\n💬 __Current phrase__: **{}**, under rule {}".format(phrase, rule_choice)
+            msg += "\n💬 __Current challenge location__: under rule {}".format(rule_choice)
             await self.bot.send_message(self.bot.modlogs_channel, msg)
 
             # find rule that puts us over 2,000 characters, if any


### PR DESCRIPTION
Small edit to message sent in #server-logs when users are unproabted to better match with new SHA1 hash approval.
Current behavior still indicates the location of a random passphrase that isn't actually there now.

Should work (tm)