### PR TITLE
Update mod.py copy

### DIFF
--- a/addons/mod.py
+++ b/addons/mod.py
@@ -98,7 +98,7 @@ welcome_footer = (
     """,
 )
 
-hidden_term_line = ' • When you have finished reading all of the rules, send a message in this channel that includes the sha1 of your discord `name#discriminator`, and we\'ll grant you access to the other channels. You can find your `name#discriminator` under the discord channel list.'
+hidden_term_line = ' • When you have finished reading all of the rules, send a message in this channel that includes the sha1 hash of your discord `name#discriminator`, and we'll grant you access to the other channels. You can find your `name#discriminator` (your username followed by a ‘#’ and four numbers) under the discord channel list. You can convert your `name#discriminator` to a sha1 hash by Googling a "sha1 hash generator”, and inputting it there.'
 
 
 class Mod:


### PR DESCRIPTION
Rules for accessing Discord channel (via discriminator to sha1 hash conversion) is confusing and vague for the layman. I added more clarity. This will ensure we aren't filtering out casual Discord users who may have something valuable to contribute. 