### PR TITLE
Update Readme to link to source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Kurisu-Reswitched
-A Discord server bot by 916253 and ihaveamac/ihaveahax. Now with 5% less memes! Forked from [Kurisu](https://reswitched.tech/meta/contributing), for the [ReSwitched](https://reswitched.tech/start) Discord server.
+A Discord server bot by 916253 and ihaveamac/ihaveahax. Now with 5% less memes! Forked from [Kurisu](https://github.com/nh-server/Kurisu), for the [ReSwitched](https://reswitched.tech/start) Discord server.
 
 Uses [discord.py](https://github.com/Rapptz/discord.py). Be sure to use the latest version for best results.


### PR DESCRIPTION
It linked to ReSwitched (https://reswitched.tech/meta/contributing) instead of the actual source (https://github.com/nh-server/Kurisu)