### PR TITLE
Remove code block formatting from secret line, add example

### DIFF
--- a/addons/mod.py
+++ b/addons/mod.py
@@ -97,7 +97,7 @@ welcome_footer = (
     """,
 )
 
-hidden_term_line = ' • When you have finished reading all of the rules, send a message in this channel that includes the SHA1 hash of your discord `name#discriminator`, and we\'ll grant you access to the other channels. You can find your `name#discriminator` (your username followed by a ‘#’ and four numbers) under the discord channel list.'
+hidden_term_line = ' • When you have finished reading all of the rules, send a message in this channel that includes the SHA1 hash of your discord "name#discriminator" (for example, User#1234), and we\'ll grant you access to the other channels. You can find your "name#discriminator" (your username followed by a ‘#’ and four numbers) under the discord channel list.'
 
 
 class Mod:


### PR DESCRIPTION
We've discussed removing the code block formatting multiple times, but never implemented it.

I also added an example of what we're looking for. We may not actually want that example, so feel free to tell me to remove it.